### PR TITLE
Refactor, Fix/#30 Todo 업데이트 기능 수정

### DIFF
--- a/src/components/TodoItem/index.tsx
+++ b/src/components/TodoItem/index.tsx
@@ -36,6 +36,7 @@ export function TodoItem({
 
   const handleCancelEdit = () => {
     if (window.confirm('수정한 내용이 사라집니다. 계속하시겠습니까?')) {
+      editInput.setValue(todo);
       setIsEditing(false);
     }
   };

--- a/src/components/TodoItem/index.tsx
+++ b/src/components/TodoItem/index.tsx
@@ -22,6 +22,10 @@ export function TodoItem({
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    if (editInput.value === todo) {
+      return setIsEditing(false);
+    }
+
     await handleUpdateTodo(id, editInput.value, isCompleted);
     setIsEditing(false);
   };

--- a/src/pages/Todo/index.tsx
+++ b/src/pages/Todo/index.tsx
@@ -23,6 +23,7 @@ export default function TodoPage() {
 
   const handleUpdateTodo = useCallback(async (id: number, todo: string, isCompleted: boolean) => {
     if (todo === '') return alert('내용을 입력해주세요.');
+
     const updatedTodo = await updateTodoAPI(id, todo, isCompleted);
     setTodos(prevTodos => prevTodos.map(prevTodo => (prevTodo.id === id ? updatedTodo : prevTodo)));
   }, []);


### PR DESCRIPTION
## 🐣 개요

Todo 수정한 내용이 없어도 API 요청이 감.
Todo 수정 취소 시 이전에 수정하던 내용이 그대로 입력됨.

## 🐣 작업사항

- TodoItem 컴포넌트의 handleSubmit 함수 안에서 수정내용과 원본을 비교하도록 변경.
- TodoItem 컴포넌트의 handleCancelEdit 함수 안에서 수정 모드를 닫으면서 수정 Input 값을 원본 값으로 변경하도록 함.
## 🐣 공유사항

* 이전에 develop브랜치에 푸쉬를 바로 해버려 revert하고 다시 PR만듭니다..!