### PR TITLE
[STYLE] : 투두 리스트 스크롤바 숨기기

### DIFF
--- a/src/pages/Todo/styles.module.scss
+++ b/src/pages/Todo/styles.module.scss
@@ -15,6 +15,11 @@
     margin-top: 3rem;
     gap: 1rem;
     overflow-y: scroll;
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; 
+  }
+  .listWrapper::-webkit-scrollbar {
+    display: none;
   }
   
   .loading {


### PR DESCRIPTION
## 🐣 개요

투두 리스트의 스크롤바를 숨기기

## 🐣 작업사항
```
.box {
    -ms-overflow-style: none; /* IE and Edge */
    scrollbar-width: none; /* Firefox */
}
.box::-webkit-scrollbar {
    display: none; /* Chrome, Safari, Opera*/
}
```
위 코드를 사용하여 스크롤바를 숨기기를 적용 

